### PR TITLE
Add smartcard option

### DIFF
--- a/remmina-plugin-rdesktop/src/plugin_config.h
+++ b/remmina-plugin-rdesktop/src/plugin_config.h
@@ -24,6 +24,6 @@
 
   #define PLUGIN_NAME        "RDESKTOP"
   #define PLUGIN_DESCRIPTION "RDESKTOP - Open a RDP connection with rdesktop"
-  #define PLUGIN_VERSION     "1.2.3.0"
+  #define PLUGIN_VERSION     "1.2.4.0"
   #define PLUGIN_APPICON     "remmina-rdesktop"
 #endif

--- a/remmina-plugin-rdesktop/src/remmina_plugin.c
+++ b/remmina-plugin-rdesktop/src/remmina_plugin.c
@@ -166,6 +166,13 @@ static gboolean remmina_plugin_rdesktop_open_connection(RemminaProtocolWidget *g
     ADD_ARGUMENT("-r", g_strdup_printf("disk:share=%s", option_str));
     g_free(option_str);
   }
+  // Redirects a smartcard to the server
+  option_str = GET_PLUGIN_STRING("smartcardname");
+  if (option_str)
+  {
+    ADD_ARGUMENT("-r", g_strdup_printf("scard:%s", option_str));
+    g_free(option_str);
+  }  
 
   if (GET_PLUGIN_BOOLEAN("fullscreen"))
   {
@@ -366,6 +373,7 @@ static const RemminaProtocolSetting remmina_plugin_rdesktop_advanced_settings[] 
   { REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "fullscreen", N_("Fullscreen"), TRUE, NULL, NULL },
   { REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "seamlessrdp", N_("Seamless RDP"), FALSE, NULL, NULL },
   { REMMINA_PROTOCOL_SETTING_TYPE_TEXT, "seamlessrdpshell", N_("Seamless RDP Shell Path"), FALSE, NULL, NULL },
+  { REMMINA_PROTOCOL_SETTING_TYPE_TEXT, "smartcardname", N_("Smartcard Name"), FALSE, NULL, NULL },
   { REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "console", N_("Attach to console (Windows 2003 / 2003 R2)"), FALSE, NULL, NULL },
   { REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "compression", N_("RDP datastream compression"), TRUE, NULL, NULL },
   { REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "bitmapcaching", N_("Bitmap caching"), FALSE, NULL, NULL },


### PR DESCRIPTION
`rdesktop` have the option for smartcard:

```
         '-r scard[:"Scard Name"="Alias Name[;Vendor Name]"[,...]]
          example: -r scard:"eToken PRO 00 00"="AKS ifdh 0"
                   "eToken PRO 00 00" -> Device in Linux/Unix enviroment
                   "AKS ifdh 0"       -> Device shown in Windows enviroment 
          example: -r scard:"eToken PRO 00 00"="AKS ifdh 0;AKS"
                   "eToken PRO 00 00" -> Device in Linux/Unix enviroment
                   "AKS ifdh 0"       -> Device shown in Windows enviroment 
                   "AKS"              -> Device vendor name                 
```

Adding an option in advance for user to setup the smartcard.