### PR TITLE
Added missing Setting names

### DIFF
--- a/remmina-plugin-rdesktop/src/remmina_plugin.c
+++ b/remmina-plugin-rdesktop/src/remmina_plugin.c
@@ -334,11 +334,11 @@ static gpointer sound_list[] =
  */
 static const RemminaProtocolSetting remmina_plugin_rdesktop_basic_settings[] =
 {
-  { REMMINA_PROTOCOL_SETTING_TYPE_SERVER, NULL, NULL, FALSE, NULL, NULL },
+  { REMMINA_PROTOCOL_SETTING_TYPE_SERVER, "server", NULL, FALSE, NULL, NULL },
   { REMMINA_PROTOCOL_SETTING_TYPE_TEXT, "username", N_("User name"), FALSE, NULL, NULL },
-  { REMMINA_PROTOCOL_SETTING_TYPE_PASSWORD, NULL, NULL, FALSE, NULL, NULL },
+  { REMMINA_PROTOCOL_SETTING_TYPE_PASSWORD, "password", NULL, FALSE, NULL, NULL },
   { REMMINA_PROTOCOL_SETTING_TYPE_TEXT, "domain", N_("Domain"), FALSE, NULL, NULL },
-  { REMMINA_PROTOCOL_SETTING_TYPE_RESOLUTION, NULL, NULL, FALSE, NULL, NULL },
+  { REMMINA_PROTOCOL_SETTING_TYPE_RESOLUTION, "resolution", NULL, FALSE, NULL, NULL },
   { REMMINA_PROTOCOL_SETTING_TYPE_SELECT, "colordepth", N_("Color depth"), FALSE, colordepth_list, NULL },
   { REMMINA_PROTOCOL_SETTING_TYPE_SELECT, "experience", N_("Experience"), FALSE, experience_list, NULL },
   { REMMINA_PROTOCOL_SETTING_TYPE_SELECT, "sound", N_("Sound"), FALSE, sound_list, NULL },


### PR DESCRIPTION
Without these names, Remmina 1.3.6 fails with 'Internal error: a setting
 name in protocol plugin RDESKTOP is null. Please fix
 RemminaProtocolSetting struct content.' and dumps core.